### PR TITLE
refactor: change copyright year into dynamic year

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -94,7 +94,7 @@ export default function SideBar() {
                 })}
             </ul>
             <footer className='mt-auto hidden md:block'>
-                <p>©2021 IMV Laboratory 🇮🇩</p>
+                <p>©{new Date().getFullYear()} IMV Laboratory 🇮🇩</p>
             </footer>
         </div>
     );

--- a/pages/auth/index.js
+++ b/pages/auth/index.js
@@ -176,7 +176,8 @@ export default function login() {
                         )}
                     </div>
                     <p className='mt-auto mb-2'>
-                        ©2021 IMV Laboratory | Bandung, Indonesia 🇮🇩
+                        ©{new Date().getFullYear()} IMV Laboratory | Bandung,
+                        Indonesia 🇮🇩
                     </p>
                 </main>
             </>


### PR DESCRIPTION
Change copyright year in the footer from static `2021` into dynamic year according to the current year from `Date` object in javascript.